### PR TITLE
Update resource cache dependency resolver

### DIFF
--- a/src/sdk/createResourceCache.js
+++ b/src/sdk/createResourceCache.js
@@ -22,20 +22,24 @@ function createResourceCache() {
   }
 
   function getWithDependencies(key) {
-    const entry = cache[key];
-    if (!entry || !entry.value) return;
-
     const ret = {};
-    ret[key] = entry.value;
-    if (entry.dependencies) {
-      entry.dependencies.forEach(dep => {
-        // stop condition to avoid infinite recursion
-        if (!ret[dep]) {
-          Object.assign(ret, getWithDependencies(dep));
-        }
-      });
+
+    function resolveDependencies(key) {
+      const entry = cache[key];
+      if (!entry || !entry.value) return;
+
+      ret[key] = entry.value;
+      if (entry.dependencies) {
+        entry.dependencies.forEach(dep => {
+          // stop condition to avoid infinite recursion
+          if (!ret[dep]) {
+            Object.assign(ret, resolveDependencies(dep));
+          }
+        });
+      }
+      return ret;
     }
-    return ret;
+    return resolveDependencies(key);
   }
 
   function remove(key) {

--- a/test/unit/sdk/createResourceCache.test.js
+++ b/test/unit/sdk/createResourceCache.test.js
@@ -59,5 +59,10 @@ describe('createResourceCache', () => {
     cache.setValue('a', 'aaa');
     cache.setDependencies('a', ['a']);
     expect(cache.getWithDependencies('a')).to.eql({a: 'aaa'});
+
+    cache.setDependencies('a', ['b']);
+    cache.setValue('b', 'bbb');
+    cache.setDependencies('b', ['a'])
+    expect(cache.getWithDependencies('a')).to.eql({a: 'aaa', b: 'bbb'});
   });
 });


### PR DESCRIPTION
## Problem

`getWithDependencies` will get caught in an infinite loop with the following resource cache, as the return object will be empty on the second pass:
```
let cache = {
  a: {
    value: 'aaa',
    dependencies: ['b']
  },
  b: {
    value: 'bbb',
    dependencies: ['a']
  }
}
```

## Fixes

* Initialize `ret` object outside of the recursive function